### PR TITLE
fix(ci): improve build concurrency and PR merge handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,20 +14,33 @@ on:
   workflow_dispatch:
 
 env:
-  IMAGE_DESC: "kourOS Customized Universal Blue Image"
+  IMAGE_DESC: "kourOS Customized Bluefin Image"
   IMAGE_KEYWORDS: "bootc,ublue,universal-blue"
   IMAGE_LOGO_URL: "https://avatars.githubusercontent.com/u/120078124?s=200&v=4"  # Put your own image here for a fancy profile on https://artifacthub.io/!
-  IMAGE_NAME: "${{ github.event.repository.name }}"  # output image name, usually same as repo name
-  IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"  # do not edit
+  IMAGE_NAME: "${{ github.event.repository.name }}"  # Output image name, usually same as repo name
+  IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"  # Do not edit
   DEFAULT_TAG: "latest"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}-${{ inputs.brand_name}}-${{ inputs.stream_name }}
+  # Don't let PR merge cancel the build
+  group: >-
+    ${{
+      contains(github.event.head_commit.message, 'Merge pull request')
+        && format('skip-concurrency-{0}', github.run_id)
+        || format(
+            '{0}-{1}-{2}-{3}',
+            github.workflow,
+            github.ref || github.run_id,
+            inputs.brand_name || 'nobrand',
+            inputs.stream_name || 'nostream'
+          )
+    }}
   cancel-in-progress: true
 
 jobs:
   build_push:
     name: Build and push image
+    if: "!contains(github.event.head_commit.message, 'Merge pull request')"  # Don't rebuild on PR merge
     runs-on: ubuntu-24.04
 
     permissions:


### PR DESCRIPTION
Update the GitHub Actions workflow to enhance concurrency control and prevent unnecessary builds on pull request merges. The concurrency group now skips cancellation for PR merges and uses default values for missing inputs. Also, the build job is skipped if the commit message indicates a PR merge. Updated some environment variable comments for clarity.