### PR TITLE
feat(ci): improve build space and caching in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,8 +49,10 @@ jobs:
       - name: Install skopeo and jq
         if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         run: |
-          sudo apt-get update
-          sudo apt-get install -y skopeo jq
+          if ! { command -v jq && command -v skopeo; } >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y skopeo jq
+          fi
 
       - name: Get current repo and base image commit
         if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
@@ -114,10 +116,11 @@ jobs:
           fi
 
       # This is optional, but if you see that your builds are way too big for the runners, you can enable this by uncommenting the following lines:
-      # - name: Maximize build space
-      #   uses: ublue-os/remove-unwanted-software@517622d6452028f266b7ba4cc9a123b5f58a6b53 # v7
-      #   with:
-      #     remove-codeql: true
+      - name: Maximize build space
+        if: steps.should_build.outputs.should_build == 'true'
+        uses: ublue-os/remove-unwanted-software@517622d6452028f266b7ba4cc9a123b5f58a6b53 # v7
+        with:
+          remove-codeql: true
 
       - name: Mount BTRFS for podman storage
         if: steps.should_build.outputs.should_build == 'true'
@@ -249,7 +252,14 @@ jobs:
           COSIGN_EXPERIMENTAL: false
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
 
-      - name: Save build input state for next run
+      - name: Save build input file
         if: steps.push.outcome == 'success'
         run: |
           echo '{"git_commit": "${{ steps.current_state.outputs.git_commit }}", "base_commit": "${{ steps.current_state.outputs.ostree_commit }}"}' > .last-build-info.json
+
+      - name: Save updated build input file to cache
+        if: steps.push.outcome == 'success'
+        uses: actions/cache/save@v4
+        with:
+          path: .last-build-info.json
+          key: build-inputs-${{ github.run_id }}


### PR DESCRIPTION
- Add conditional installation of skopeo and jq to avoid redundant installs.
- Enable "Maximize build space" step when build is needed, using ublue-os action.
- Save build input state to a file and cache it with actions/cache/save.
- Improve workflow efficiency and runner disk usage for main branch builds.