### PR TITLE
feat(ci): split build and publish logic in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,34 +94,67 @@ jobs:
           echo "Last Base: $LAST_BASE"
           echo "Current:   ${{ steps.current_state.outputs.ostree_commit }}"
 
-
-      - name: Check if skipping build
-        id: should_build
+      - name: Check if skipping build and/or publish
+        id: should_build_publish
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "should_build=true" >> $GITHUB_OUTPUT
-            echo "👋 This workflow was triggered manually. Building."
-          # Cache was hit, so we don't need to rebuild
-          elif [ -f .last-build-info.json ]; then
-            echo "should_build=false" >> $GITHUB_OUTPUT
-            echo "✅ No changes to base image detected. Skipping build."
-          else
-            echo "should_build=true" >> $GITHUB_OUTPUT
+          # Determine if we're on the default branch (and not a pull request).
+          default_branch=false
+          if [ "${{ github.event_name }}" != "pull_request" ] && \
+             [ "${{ github.ref }}" = "refs/heads/${{ github.event.repository.default_branch }}" ]; then
+            default_branch=true
           fi
+
+          # Decide whether to build.
+
+          # Always build when triggered manually.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            should_build=true
+            echo "📦 Manual trigger detected – building."
+          # Always build for pull requests or non-default branches.
+          elif [ "$default_branch" != "true" ]; then
+            should_build=true
+            echo "📦 Building for PR or non-default branch."
+          # On the default branch, build only if the base image has changed.
+          elif [ -f .last-build-info.json ]; then
+            should_build=false
+            echo "✅ No base image changes detected – skipping build."
+          else
+            should_build=true
+            echo "📦 Base image changed – building."
+          fi
+
+          echo "should_build=$should_build" >> "$GITHUB_OUTPUT"
+
+          # Decide whether to publish.
+
+          # Skip publish if we’re not building.
+          if [ "$should_build" != "true" ]; then
+            should_publish=false
+            echo "🙅‍♂️ Skipping publish – nothing will be built."
+          # Publish only if building from the default branch.
+          elif [ "$default_branch" = "true" ]; then
+            should_publish=true
+            echo "📤 Publishing – build from default branch."
+          else
+            should_publish=false
+            echo "🙅‍♂️ Skipping publish – not on default branch."
+          fi
+
+          echo "should_publish=$should_publish" >> "$GITHUB_OUTPUT"
 
       # This is optional, but if you see that your builds are way too big for the runners, you can enable this by uncommenting the following lines:
       - name: Maximize build space
-        if: steps.should_build.outputs.should_build == 'true'
+        if: steps.should_build_publish.outputs.should_build == 'true'
         uses: ublue-os/remove-unwanted-software@cc0becac701cf642c8f0a6613bbdaf5dc36b259e # v9
         with:
           remove-codeql: true
 
       - name: Mount BTRFS for podman storage
-        if: steps.should_build.outputs.should_build == 'true'
+        if: steps.should_build_publish.outputs.should_build == 'true'
         uses: ublue-os/container-storage-action@main
 
       - name: Get current date
-        if: steps.should_build.outputs.should_build == 'true'
+        if: steps.should_build_publish.outputs.should_build == 'true'
         id: date
         run: |
           # This generates a timestamp like what is defined on the ArtifactHub documentation
@@ -133,7 +166,7 @@ jobs:
       # Image metadata for https://artifacthub.io/ - This is optional but is highly recommended so we all can get a index of all the custom images
       # The metadata by itself is not going to do anything, you choose if you want your image to be on ArtifactHub or not.
       - name: Image Metadata
-        if: steps.should_build.outputs.should_build == 'true'
+        if: steps.should_build_publish.outputs.should_build == 'true'
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
         id: metadata
         with:
@@ -165,7 +198,7 @@ jobs:
           sep-annotations: " "
 
       - name: Build Image
-        if: steps.should_build.outputs.should_build == 'true'
+        if: steps.should_build_publish.outputs.should_build == 'true'
         id: build_image
         uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2
         with:
@@ -205,7 +238,7 @@ jobs:
       # These `if` statements are so that pull requests for your custom images do not make it publish any packages under your name without you knowing
       # They also check if the runner is on the default branch so that things like the merge queue (if you enable it), are going to work
       - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && steps.should_build.outputs.should_build == 'true'
+        if: steps.should_build_publish.outputs.should_publish == 'true'
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
         with:
           registry: ghcr.io
@@ -213,7 +246,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push To GHCR
-        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && steps.should_build.outputs.should_build == 'true'
+        if: steps.should_build_publish.outputs.should_publish == 'true'
         uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2
         id: push
         env:


### PR DESCRIPTION
Refactor build workflow to separate build and publish decisions. Adds distinct outputs for should_build and should_publish, ensuring images are only published when built on the default branch. Updates dependent steps to use new output variables for conditional execution.