### PR TITLE
feat(ci): add workflows for latest and workstation images

### DIFF
--- a/.github/workflows/build-disk.yml
+++ b/.github/workflows/build-disk.yml
@@ -97,7 +97,7 @@ jobs:
           retention-days: 0
           compression-level: 0
           overwrite: true
-      
+
       - name: Upload to S3
         if: inputs.upload-to-s3 == true && github.event_name != 'pull_request'
         shell: bash

--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -1,0 +1,21 @@
+---
+name: Build latest container image
+on:
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '05 10 * * *'  # 10:05am UTC everyday
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
+jobs:
+  build_image:
+    uses: ./.github/workflows/build.yml
+    secrets: inherit
+    with:
+      image_flavor: latest

--- a/.github/workflows/build-workstation.yml
+++ b/.github/workflows/build-workstation.yml
@@ -1,0 +1,21 @@
+---
+name: Build workstation container image
+on:
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '11 11 * * *'  # 11:11am UTC everyday
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
+jobs:
+  build_image:
+    uses: ./.github/workflows/build.yml
+    secrets: inherit
+    with:
+      image_flavor: workstation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,10 @@
 ---
 name: Build container image
 on:
-  pull_request:
-    branches:
-      - main
-  schedule:
-    - cron: '05 10 * * *'  # 10:05am UTC everyday
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      image_flavor:
+        type: string
 
 env:
   IMAGE_DESC: "kourOS Customized Bluefin Image"
@@ -14,15 +12,15 @@ env:
   IMAGE_LOGO_URL: "https://avatars.githubusercontent.com/u/120078124?s=200&v=4"  # Put your own image here for a fancy profile on https://artifacthub.io/!
   IMAGE_NAME: "${{ github.event.repository.name }}"  # Output image name, usually same as repo name
   IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"  # Do not edit
-  DEFAULT_TAG: "latest"
+  DEFAULT_TAG: "${{ inputs.image_flavor || 'latest' }}"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}-${{ inputs.brand_name}}-${{ inputs.stream_name }}
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}-${{ inputs.image_flavor }}
   cancel-in-progress: true
 
 jobs:
   build_push:
-    name: Build and push image
+    name: Build and push ${{ inputs.image_flavor || 'latest' }} image
     runs-on: ubuntu-24.04
 
     permissions:
@@ -209,6 +207,8 @@ jobs:
           image: ${{ env.IMAGE_NAME }}
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
+          build-args: |
+            TAG=${{ env.DEFAULT_TAG }}
           oci: false
 
       # Rechunk is a script that we use on Universal Blue to make sure there isnt a single huge layer when your image gets published.

--- a/Containerfile
+++ b/Containerfile
@@ -5,6 +5,8 @@ COPY build_files /
 # Base Image
 FROM ghcr.io/ublue-os/bluefin-dx:gts
 
+ARG TAG="latest"
+
 ## Other possible base images include:
 # FROM ghcr.io/ublue-os/bazzite:stable
 # FROM ghcr.io/ublue-os/bazzite:latest

--- a/Justfile
+++ b/Justfile
@@ -1,4 +1,4 @@
-export image_name := env("IMAGE_NAME", "image-template")
+export image_name := env("IMAGE_NAME", "kourOS")
 export default_tag := env("DEFAULT_TAG", "latest")
 export bib_image := env("BIB_IMAGE", "quay.io/centos-bootc/bootc-image-builder:latest")
 
@@ -93,6 +93,8 @@ build $target_image=image_name $tag=default_tag:
     if [[ -z "$(git status -s)" ]]; then
         BUILD_ARGS+=("--build-arg" "SHA_HEAD_SHORT=$(git rev-parse --short HEAD)")
     fi
+
+    BUILD_ARGS+=("--build-arg" "TAG=${tag}")
 
     podman build \
         "${BUILD_ARGS[@]}" \


### PR DESCRIPTION
- Introduced separate GitHub Actions workflows to build and push "latest" and "workstation" container images on schedule, pull request, or manual dispatch.
- Refactored main build workflow to support workflow_call and accept image_flavor input for flexible image builds.
- Minor formatting fixes in build-disk workflow.