### PR TITLE
feat: add silverblue flavor and update default tag to laptop

### DIFF
--- a/.github/workflows/build-disk.yml
+++ b/.github/workflows/build-disk.yml
@@ -10,11 +10,20 @@ on:
         default: false
         type: boolean
       platform:
+        description: "Platform"
         required: true
         type: choice
         options:
           - amd64
           - arm64
+      image-flavor:
+        description: "Image flavor"
+        required: true
+        type: choice
+        options:
+          - laptop
+          - workstation
+          - silverblue
   pull_request:
     branches:
       - main
@@ -26,7 +35,7 @@ on:
 env:
   IMAGE_NAME: ${{ github.event.repository.name }} # output of build.yml, keep in sync
   IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"  # do not edit
-  DEFAULT_TAG: "latest"
+  DEFAULT_TAG:  ${{ inputs.image-flavor }}
   BIB_IMAGE: "ghcr.io/lorbuschris/bootc-image-builder:20250608" # "quay.io/centos-bootc/bootc-image-builder:latest" - see https://github.com/osbuild/bootc-image-builder/pull/954
 
 concurrency:

--- a/.github/workflows/build-laptop.yml
+++ b/.github/workflows/build-laptop.yml
@@ -1,5 +1,5 @@
 ---
-name: Build latest container image
+name: Build laptop container image
 on:
   pull_request:
     branches:
@@ -18,4 +18,4 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     secrets: inherit
     with:
-      image_flavor: latest
+      image_flavor: laptop

--- a/.github/workflows/build-silverblue.yml
+++ b/.github/workflows/build-silverblue.yml
@@ -1,11 +1,11 @@
 ---
 name: Build silverblue container image
 on:
-  pull_request:
-    branches:
-      - main
-  schedule:
-    - cron: '12 12 * * *'  # 12:12 UTC everyday
+  # pull_request:
+  #   branches:
+  #     - main
+  # schedule:
+  #   - cron: '12 12 * * *'  # 12:12 UTC everyday
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-silverblue.yml
+++ b/.github/workflows/build-silverblue.yml
@@ -1,0 +1,21 @@
+---
+name: Build silverblue container image
+on:
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '12 12 * * *'  # 12:12 UTC everyday
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
+jobs:
+  build_image:
+    uses: ./.github/workflows/build_reusable.yml
+    secrets: inherit
+    with:
+      image_flavor: silverblue

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -12,15 +12,15 @@ env:
   IMAGE_LOGO_URL: "https://avatars.githubusercontent.com/u/120078124?s=200&v=4"  # Put your own image here for a fancy profile on https://artifacthub.io/!
   IMAGE_NAME: "${{ github.event.repository.name }}"  # Output image name, usually same as repo name
   IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"  # Do not edit
-  DEFAULT_TAG: "${{ inputs.image_flavor || 'latest' }}"
+  DEFAULT_TAG: "${{ inputs.image_flavor || 'laptop' }}"
 
 concurrency:
-  group: ${{ inputs.image_flavor || 'latest' }}-${{ github.ref || github.run_id }}-${{ inputs.image_flavor }}
+  group: ${{ inputs.image_flavor || 'laptop' }}-${{ github.ref || github.run_id }}-${{ inputs.image_flavor }}
   cancel-in-progress: true
 
 jobs:
   build_push:
-    name: Build and push ${{ inputs.image_flavor || 'latest' }} image
+    name: Build and push ${{ inputs.image_flavor || 'laptop' }} image
     runs-on: ubuntu-24.04
 
     permissions:
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Preprocess Containerfile.in
-        run: cpp -P -D${{ env.DEFAULT_TAG }} Containerfile.in -o Containerfile
+        run: cpp -P -DCPP_${{ env.DEFAULT_TAG }} Containerfile.in -o Containerfile
 
       - name: Install skopeo and jq
         if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
@@ -79,7 +79,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .last-build-info.json
-          key: build-state-${{ inputs.image_flavor || 'latest' }}-${{ hashFiles('.curr-base-commit.json') }}
+          key: build-state-${{ inputs.image_flavor || 'laptop' }}-${{ hashFiles('.curr-base-commit.json') }}
 
       - name: Compare with last build state
         if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -7,7 +7,7 @@ on:
         type: string
 
 env:
-  IMAGE_DESC: "kourOS Customized Bluefin Image"
+  IMAGE_DESC: "kourOS Customized Universal Blue Image"
   IMAGE_KEYWORDS: "bootc,ublue,universal-blue,bluefin"
   IMAGE_LOGO_URL: "https://avatars.githubusercontent.com/u/120078124?s=200&v=4"  # Put your own image here for a fancy profile on https://artifacthub.io/!
   IMAGE_NAME: "${{ github.event.repository.name }}"  # Output image name, usually same as repo name

--- a/Containerfile.in
+++ b/Containerfile.in
@@ -8,17 +8,20 @@ COPY build_files /
 # CentOS base images: quay.io/centos-bootc/centos-bootc:stream10
 */
 
-#if defined workstation
+#if defined CPP_laptop
+#define TAG "laptop"
+FROM ghcr.io/ublue-os/bluefin-dx:gts
+
+#elif defined CPP_workstation
 #define TAG "workstation"
 FROM ghcr.io/ublue-os/bluefin-dx:gts
 
-#elif defined silverblue
+#elif defined CPP_silverblue
 #define TAG "silverblue"
 FROM ghcr.io/ublue-os/silverblue-main:latest
 
 #else
-#define TAG "latest"
-FROM ghcr.io/ublue-os/bluefin-dx:gts
+#error "Unknown tag"
 #endif
 
 RUN --mount=type=bind,from=ctx,source=/,target=/ctx \

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,5 @@
 export image_name := env("IMAGE_NAME", "kouros")
-export default_tag := env("DEFAULT_TAG", "latest")
+export default_tag := env("DEFAULT_TAG", "laptop")
 export bib_image := env("BIB_IMAGE", "quay.io/centos-bootc/bootc-image-builder:latest")
 
 alias build-vm := build-qcow2
@@ -94,7 +94,7 @@ build $target_image=image_name $tag=default_tag:
         BUILD_ARGS+=("--build-arg" "SHA_HEAD_SHORT=$(git rev-parse --short HEAD)")
     fi
 
-    BUILD_ARGS+=("--cpp-flag=-D${tag}")
+    BUILD_ARGS+=("--cpp-flag=-DCPP_${tag}")
 
     podman build \
         "${BUILD_ARGS[@]}" \

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # kourOS
 
-This repo was built on the [Universal Blue Image Template](https://github.com/ublue-os/image-template) and slightly modified for my needs, mostly just to create `/nix` in Bluefin.
+This repo was built on the [Universal Blue Image Template](https://github.com/ublue-os/image-template).
+
+The scheduled build rebuilds images only when there were changes to the base image.
 
 ## Rebasing
 
-You can rebase to an **kourOS** image using the following:
+You can rebase to **kourOS** images using one of the following:
 
 ```console
-sudo bootc switch --enforce-container-sigpolicy ghcr.io/mkoura/kouros:latest
+sudo bootc switch --enforce-container-sigpolicy ghcr.io/mkoura/kouros:laptop
+sudo bootc switch --enforce-container-sigpolicy ghcr.io/mkoura/kouros:workstation
+sudo bootc switch --enforce-container-sigpolicy ghcr.io/mkoura/kouros:silverblue
 ```

--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -22,17 +22,47 @@ TAG="${1:?"Tag needs to be provided"}"
 LAYERED_PACKAGES=(
   ansible
   foot
+  nmap
   papirus-icon-theme
+  tcpdump
+  wireshark
+  wireshark-cli
+)
+
+LAYERED_PACKAGES_LAPTOP=(
+  kismet
+)
+
+LAYERED_PACKAGES_WORKSTATION=(
+  dracut-sshd
+)
+
+LAYERED_PACKAGES_SILVERBLUE=(
+  bat
+  fd-find
+  fzf
+  mc
+  neovim
+  tmux
+  zoxide
 )
 
 case "$TAG" in
+  laptop)
+    dnf5 install --setopt=install_weak_deps=False -y "${LAYERED_PACKAGES[@]}" "${LAYERED_PACKAGES_LAPTOP[@]}"
+    ;;
   workstation)
     dnf5 -y copr enable gsauthof/dracut-sshd
-    dnf5 install --setopt=install_weak_deps=False -y "${LAYERED_PACKAGES[@]}" dracut-sshd
+    dnf5 install --setopt=install_weak_deps=False -y "${LAYERED_PACKAGES[@]}" "${LAYERED_PACKAGES_WORKSTATION[@]}"
     dnf5 -y copr disable gsauthof/dracut-sshd
     ;;
+  silverblue)
+    dnf5 install --setopt=install_weak_deps=False -y "${LAYERED_PACKAGES[@]}" "${LAYERED_PACKAGES_SILVERBLUE[@]}"
+    ;;
   *)
-    dnf5 install --setopt=install_weak_deps=False -y "${LAYERED_PACKAGES[@]}"
+    echo "Unknown tag: $TAG" >&2
+    exit 1
+    ;;
 esac
 
 ostree container commit

--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -21,12 +21,19 @@ TAG="${1:?"Tag needs to be provided"}"
 
 LAYERED_PACKAGES=(
   ansible
+  bat
+  fd-find
   foot
+  fzf
+  mc
+  neovim
   nmap
   papirus-icon-theme
   tcpdump
+  tmux
   wireshark
   wireshark-cli
+  zoxide
 )
 
 LAYERED_PACKAGES_LAPTOP=(
@@ -35,16 +42,6 @@ LAYERED_PACKAGES_LAPTOP=(
 
 LAYERED_PACKAGES_WORKSTATION=(
   dracut-sshd
-)
-
-LAYERED_PACKAGES_SILVERBLUE=(
-  bat
-  fd-find
-  fzf
-  mc
-  neovim
-  tmux
-  zoxide
 )
 
 case "$TAG" in
@@ -57,7 +54,7 @@ case "$TAG" in
     dnf5 -y copr disable gsauthof/dracut-sshd
     ;;
   silverblue)
-    dnf5 install --setopt=install_weak_deps=False -y "${LAYERED_PACKAGES[@]}" "${LAYERED_PACKAGES_SILVERBLUE[@]}"
+    dnf5 install --setopt=install_weak_deps=False -y "${LAYERED_PACKAGES[@]}"
     ;;
   *)
     echo "Unknown tag: $TAG" >&2


### PR DESCRIPTION
- Introduce a new GitHub Actions workflow for building the "silverblue" container image flavor.
- Update reusable workflow, Justfile, and build scripts to use "laptop" as the default tag instead of "latest".
- Refactor Containerfile.in to handle "laptop", "workstation", and "silverblue" tags explicitly, with an error for unknown tags.
- Extend build.sh to support layered packages for each flavor, including new packages for "laptop" and "silverblue".